### PR TITLE
Refactor SFC to FC

### DIFF
--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -27,7 +27,7 @@ interface PageTemplateProps {
   }
 }
 
-const PageTemplate: React.SFC<PageTemplateProps> = ({ data }) => (
+const PageTemplate: React.FC<PageTemplateProps> = ({ data }) => (
   <IndexLayout>
     <Page>
       <Container>


### PR DESCRIPTION
Thank you for very useful starter. 👍 
 I refactor `SFC` to `FC` because `SFC` is deprecated.

Relation #7 